### PR TITLE
🤖 Auto-update: Monthly ticket purchaser analysis for Q4 2024

### DIFF
--- a/ad_hoc/LOVB_2171_past_ticket_purchasers/LOVB-2171 past ticket purchasers.sql
+++ b/ad_hoc/LOVB_2171_past_ticket_purchasers/LOVB-2171 past ticket purchasers.sql
@@ -8,23 +8,10 @@ with _select as (
 		address_state,
 		event_code, 
 		match_date,
-		extract(week from match_date) as match_week
+		extract(month from match_date) as match_month
 	from prod_intermediate.int_single_ticket_purchase
 	where coalesce(first_name, last_name, '') != ''
-), 
-
-_adj_match_week as (
-	select 
-		first_name,
-		last_name, 
-		email, 
-		phone_number,
-		address_city, 
-		address_state,
-		event_code, 
-		match_date,
-		match_week - (select min(match_week) from _select) + 1 as match_week
-	from _select
+		and match_date >= '2024-10-01' and match_date < '2025-01-01'
 ), 
 
 _rank as (
@@ -35,10 +22,9 @@ _rank as (
 		phone_number,
 		address_city, 
 		address_state,
-		row_number() over(partition by email order by last_name, first_name, phone_number, match_week) as row_id
+		row_number() over(partition by email order by last_name, first_name, phone_number) as row_id
 	from _select
 ), 
-
 
 _unique as (
 	select 
@@ -52,44 +38,24 @@ _unique as (
 	where row_id = 1
 ), 
 
-_email_weeks as (
+_email_months as (
 
 	select email, 
-		max(case when match_week = 1 then 1 else 0 end) :: BOOLEAN as week_1,
-		max(case when match_week = 2 then 1 else 0 end) :: BOOLEAN as week_2,
-		max(case when match_week = 3 then 1 else 0 end) :: BOOLEAN as week_3,
-		max(case when match_week = 4 then 1 else 0 end) :: BOOLEAN as week_4,
-		max(case when match_week = 5 then 1 else 0 end) :: BOOLEAN as week_5,
-		max(case when match_week = 6 then 1 else 0 end) :: BOOLEAN as week_6,
-		max(case when match_week = 7 then 1 else 0 end) :: BOOLEAN as week_7,
-		max(case when match_week = 8 then 1 else 0 end) :: BOOLEAN as week_8,
-		max(case when match_week = 9 then 1 else 0 end) :: BOOLEAN as week_9,
-		max(case when match_week = 10 then 1 else 0 end) :: BOOLEAN as week_10,
-		max(case when match_week = 11 then 1 else 0 end) :: BOOLEAN as week_11,
-		max(case when match_week = 12 then 1 else 0 end) :: BOOLEAN as week_12,
-		max(case when match_week = 13 then 1 else 0 end) :: BOOLEAN as week_13
-	from _adj_match_week
+		count(case when match_month = 10 then 1 end) as october_purchases,
+		count(case when match_month = 11 then 1 end) as november_purchases,
+		count(case when match_month = 12 then 1 end) as december_purchases
+	from _select
 	group by email
 ),
 
 _combined as (
 	select 
 		a.*,
-		b.week_1,
-		b.week_2,
-		b.week_3,
-		b.week_4,
-		b.week_5,
-		b.week_6,
-		b.week_7,
-		b.week_8,
-		b.week_9,
-		b.week_10,
-		b.week_11,
-		b.week_12,
-		b.week_13
+		b.october_purchases,
+		b.november_purchases,
+		b.december_purchases
 	from _unique as a
-	left join _email_weeks as b 
+	left join _email_months as b 
 	on a.email = b.email
 ),
 
@@ -100,5 +66,3 @@ _final as (
 )
 
 select * from _final order by address_state, address_city, last_name;
-;
-


### PR DESCRIPTION
## Automated Code Modification

**Original Request:** Monthly ticket purchaser analysis for Q4 2024

**Description:** Hi team,

I need a monthly breakdown of our ticket purchasers for Q4 2024 (October, November, December). This is for our quarterly business review.

**What I need:**
- Customer contact information (names, emails, phone numbers)
- Monthly purchase totals instead of weekly
- Customer segmentation by purchase frequency
- Geographic distribution by market

**Why:** Quarterly business review needs monthly aggregated data rather than weekly details.

**Timeline:** Need this for the QBR presentation next week.

**Note:** I know we have weekly ticket purchaser analysis, but I need this aggregated to monthly level.

**Based on existing work:** `ad_hoc/LOVB_2171_past_ticket_purchasers/Past_Ticket_Purchasers_Analysis_Report.md`

**Changes Applied:**


**⚠️ Please Review:**
- Verify the SQL logic is correct
- Test with sample data
- Confirm output format meets requirements

*This pull request was created automatically by the Analytics Work Reuse Tool.*
