### PR TITLE
🤖 Auto-update: Monthly ticket purchaser analysis for Q4 2024 - Enhanced Test

### DIFF
--- a/ad_hoc/LOVB_2171_past_ticket_purchasers/LOVB-2171 past ticket purchasers.sql
+++ b/ad_hoc/LOVB_2171_past_ticket_purchasers/LOVB-2171 past ticket purchasers.sql
@@ -8,23 +8,11 @@ with _select as (
 		address_state,
 		event_code, 
 		match_date,
-		extract(week from match_date) as match_week
+		extract(month from match_date) as match_month,
+		extract(year from match_date) as match_year
 	from prod_intermediate.int_single_ticket_purchase
 	where coalesce(first_name, last_name, '') != ''
-), 
-
-_adj_match_week as (
-	select 
-		first_name,
-		last_name, 
-		email, 
-		phone_number,
-		address_city, 
-		address_state,
-		event_code, 
-		match_date,
-		match_week - (select min(match_week) from _select) + 1 as match_week
-	from _select
+		and match_date >= '2024-10-01' and match_date < '2025-01-01'
 ), 
 
 _rank as (
@@ -35,10 +23,11 @@ _rank as (
 		phone_number,
 		address_city, 
 		address_state,
-		row_number() over(partition by email order by last_name, first_name, phone_number, match_week) as row_id
+		count(*) as purchase_count,
+		row_number() over(partition by email order by last_name, first_name, phone_number) as row_id
 	from _select
+	group by first_name, last_name, email, phone_number, address_city, address_state
 ), 
-
 
 _unique as (
 	select 
@@ -47,49 +36,28 @@ _unique as (
 		email, 
 		phone_number,
 		address_city, 
-		address_state
+		address_state,
+		purchase_count
 	from _rank
 	where row_id = 1
 ), 
 
-_email_weeks as (
-
-	select email, 
-		max(case when match_week = 1 then 1 else 0 end) :: BOOLEAN as week_1,
-		max(case when match_week = 2 then 1 else 0 end) :: BOOLEAN as week_2,
-		max(case when match_week = 3 then 1 else 0 end) :: BOOLEAN as week_3,
-		max(case when match_week = 4 then 1 else 0 end) :: BOOLEAN as week_4,
-		max(case when match_week = 5 then 1 else 0 end) :: BOOLEAN as week_5,
-		max(case when match_week = 6 then 1 else 0 end) :: BOOLEAN as week_6,
-		max(case when match_week = 7 then 1 else 0 end) :: BOOLEAN as week_7,
-		max(case when match_week = 8 then 1 else 0 end) :: BOOLEAN as week_8,
-		max(case when match_week = 9 then 1 else 0 end) :: BOOLEAN as week_9,
-		max(case when match_week = 10 then 1 else 0 end) :: BOOLEAN as week_10,
-		max(case when match_week = 11 then 1 else 0 end) :: BOOLEAN as week_11,
-		max(case when match_week = 12 then 1 else 0 end) :: BOOLEAN as week_12,
-		max(case when match_week = 13 then 1 else 0 end) :: BOOLEAN as week_13
-	from _adj_match_week
-	group by email
+_monthly_totals as (
+	select 
+		email,
+		match_month,
+		count(*) as total_purchases
+	from _select
+	group by email, match_month
 ),
 
 _combined as (
 	select 
 		a.*,
-		b.week_1,
-		b.week_2,
-		b.week_3,
-		b.week_4,
-		b.week_5,
-		b.week_6,
-		b.week_7,
-		b.week_8,
-		b.week_9,
-		b.week_10,
-		b.week_11,
-		b.week_12,
-		b.week_13
+		b.match_month,
+		b.total_purchases
 	from _unique as a
-	left join _email_weeks as b 
+	left join _monthly_totals as b 
 	on a.email = b.email
 ),
 
@@ -99,6 +67,15 @@ _final as (
 	where not exists (select 1 from prod_raw.stg_braze_unsub as b where a.email = b.email)
 )
 
-select * from _final order by address_state, address_city, last_name;
-;
-
+select 
+	address_state,
+	address_city,
+	last_name,
+	first_name,
+	email,
+	phone_number,
+	purchase_count,
+	match_month,
+	total_purchases
+from _final 
+order by address_state, address_city, last_name, match_month;


### PR DESCRIPTION
## Automated Code Modification

**Original Request:** Monthly ticket purchaser analysis for Q4 2024 - Enhanced Test

**Description:** Hi team,

I need a monthly breakdown of our ticket purchasers for Q4 2024 (October, November, December). This is for our quarterly business review.

**What I need:**
- Customer contact information (names, emails, phone numbers)
- Monthly purchase totals instead of weekly
- Customer segmentation by purchase frequency
- Geographic distribution by market

**Why:** Quarterly business review needs monthly aggregated data rather than weekly details.

**Timeline:** Need this for the QBR presentation next week.

**Note:** I know we have weekly ticket purchaser analysis, but I need this aggregated to monthly level.

**Based on existing work:** `ad_hoc/LOVB_2171_past_ticket_purchasers/Past_Ticket_Purchasers_Analysis_Report.md`

**Changes Applied:**


**⚠️ Please Review:**
- Verify the SQL logic is correct
- Test with sample data
- Confirm output format meets requirements

*This pull request was created automatically by the Analytics Work Reuse Tool.*
